### PR TITLE
Implement simple stop-loss strategy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/ZhouDavid/trade-sonic
 
 go 1.24.0
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/strategy-engine/cmd/engine/config.json
+++ b/strategy-engine/cmd/engine/config.json
@@ -6,12 +6,10 @@
     },
     "strategies": [
         {
-            "name": "simple_ma_cross",
-            "type": "moving_average_cross",
+            "name": "btc_stop_loss",
+            "type": "stop_loss",
             "parameters": {
-                "short_period": 10,
-                "long_period": 20,
-                "symbols": ["BTC-USD", "ETH-USD"]
+                "max_drawdown_percent": 5.0
             }
         }
     ]

--- a/strategy-engine/cmd/engine/main.go
+++ b/strategy-engine/cmd/engine/main.go
@@ -6,12 +6,14 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/ZhouDavid/trade-sonic/strategy-engine/internal/engine"
 	"github.com/ZhouDavid/trade-sonic/strategy-engine/internal/strategy"
+	"github.com/ZhouDavid/trade-sonic/strategy-engine/internal/strategy/stoploss"
 )
 
 // Config holds the configuration for the strategy engine
@@ -52,10 +54,28 @@ func main() {
 
 	// Initialize strategies from config
 	for _, stratCfg := range config.Strategies {
-		// In a real implementation, you would have a strategy factory
-		// that creates the appropriate strategy based on stratCfg.Type
-		// For now, we'll just log
-		log.Printf("Would initialize strategy: %s of type %s\n", stratCfg.Name, stratCfg.Type)
+		var strat strategy.Strategy
+		var err error
+
+		switch stratCfg.Type {
+		case "stop_loss":
+			strat, err = stoploss.NewStopLossStrategy(stratCfg.Parameters)
+		default:
+			log.Printf("Unknown strategy type: %s\n", stratCfg.Type)
+			continue
+		}
+
+		if err != nil {
+			log.Printf("Error initializing strategy %s: %v\n", stratCfg.Name, err)
+			continue
+		}
+
+		if err := strategyEngine.RegisterStrategy(strat); err != nil {
+			log.Printf("Error registering strategy %s: %v\n", stratCfg.Name, err)
+			continue
+		}
+
+		log.Printf("Successfully initialized and registered strategy: %s\n", stratCfg.Name)
 	}
 
 	// Create context that can be cancelled
@@ -89,43 +109,46 @@ func main() {
 }
 
 func loadConfig() *Config {
-	// Try to load config from file
-	configFile := "config.json"
+	// Try to load config file from the same directory as the binary
+	execPath, err := os.Executable()
+	if err != nil {
+		log.Printf("Could not get executable path: %v, using default config", err)
+		return getDefaultConfig()
+	}
+
+	configFile := filepath.Join(filepath.Dir(execPath), "config.json")
+	// Also check in the current directory as fallback
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		configFile = "strategy-engine/cmd/engine/config.json"
+	}
 	data, err := os.ReadFile(configFile)
 	if err != nil {
 		log.Printf("Could not read config file: %v, using default config", err)
-		// Return default config if file cannot be read
-		return &Config{
-			QueueConfig: struct {
-				Address string `json:"address"`
-				Channel string `json:"channel"`
-				GroupID string `json:"groupId"`
-			}{
-				Address: "localhost:6379",
-				Channel: "market_data",
-				GroupID: "strategy_engine",
-			},
-		}
+		return getDefaultConfig()
 	}
 
 	var config Config
 	if err := json.Unmarshal(data, &config); err != nil {
 		log.Printf("Could not parse config file: %v, using default config", err)
-		// Return default config if file cannot be parsed
-		return &Config{
-			QueueConfig: struct {
-				Address string `json:"address"`
-				Channel string `json:"channel"`
-				GroupID string `json:"groupId"`
-			}{
-				Address: "localhost:6379",
-				Channel: "market_data",
-				GroupID: "strategy_engine",
-			},
-		}
+		return getDefaultConfig()
 	}
 
 	return &config
+}
+
+// getDefaultConfig returns the default configuration
+func getDefaultConfig() *Config {
+	return &Config{
+		QueueConfig: struct {
+			Address string `json:"address"`
+			Channel string `json:"channel"`
+			GroupID string `json:"groupId"`
+		}{
+			Address: "localhost:6379",
+			Channel: "market_data",
+			GroupID: "strategy_engine",
+		},
+	}
 }
 
 func consumeMarketData(ctx context.Context, e *engine.Engine, cfg *Config) {

--- a/strategy-engine/internal/strategy/stoploss/strategy.go
+++ b/strategy-engine/internal/strategy/stoploss/strategy.go
@@ -1,0 +1,141 @@
+package stoploss
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ZhouDavid/trade-sonic/strategy-engine/internal/strategy"
+)
+
+// StopLossStrategy implements a simple stop loss strategy based on maximum drawdown
+type StopLossStrategy struct {
+	mu sync.RWMutex
+
+	// Strategy parameters
+	maxDrawdownPercent float64             // Maximum allowed drawdown in percentage
+	positions          map[string]Position // Current positions keyed by symbol
+
+	name string
+}
+
+// Position tracks the position details for a symbol
+type Position struct {
+	EntryPrice     float64   // Price at which we entered the position
+	HighestPrice   float64   // Highest price seen since entry
+	Quantity       float64   // Current position quantity
+	LastUpdateTime time.Time // Last time this position was updated
+}
+
+// NewStopLossStrategy creates a new instance of StopLossStrategy
+func NewStopLossStrategy(params map[string]interface{}) (*StopLossStrategy, error) {
+	maxDrawdown, ok := params["max_drawdown_percent"].(float64)
+	if !ok {
+		return nil, fmt.Errorf("max_drawdown_percent must be a float64")
+	}
+
+	if maxDrawdown <= 0 || maxDrawdown >= 100 {
+		return nil, fmt.Errorf("max_drawdown_percent must be between 0 and 100")
+	}
+
+	return &StopLossStrategy{
+		maxDrawdownPercent: maxDrawdown,
+		positions:          make(map[string]Position),
+		name:               "stop_loss_strategy",
+	}, nil
+}
+
+// Initialize implements strategy.Strategy
+func (s *StopLossStrategy) Initialize(ctx context.Context) error {
+	return nil
+}
+
+// ProcessData implements strategy.Strategy
+func (s *StopLossStrategy) ProcessData(ctx context.Context, data strategy.MarketData) (*strategy.Signal, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	pos, exists := s.positions[data.Symbol]
+	if !exists {
+		// No position for this symbol yet, track it as a potential entry
+		s.positions[data.Symbol] = Position{
+			EntryPrice:     data.Price,
+			HighestPrice:   data.Price,
+			Quantity:       0, // No position yet
+			LastUpdateTime: data.Timestamp,
+		}
+		return nil, nil
+	}
+
+	// Update position tracking
+	if data.Price > pos.HighestPrice {
+		pos.HighestPrice = data.Price
+		s.positions[data.Symbol] = pos
+	}
+
+	// If we have an active position, check for stop loss
+	if pos.Quantity > 0 {
+		currentDrawdown := (pos.HighestPrice - data.Price) / pos.HighestPrice * 100
+
+		if currentDrawdown >= s.maxDrawdownPercent {
+			// Generate sell signal - stop loss triggered
+			signal := &strategy.Signal{
+				Symbol:      data.Symbol,
+				Action:      strategy.SignalActionSell,
+				Price:       data.Price,
+				Quantity:    pos.Quantity,
+				Confidence:  1.0, // High confidence for stop loss
+				GeneratedAt: data.Timestamp,
+				ExpiresAt:   data.Timestamp.Add(time.Minute), // Signal expires in 1 minute
+				Metadata: map[string]interface{}{
+					"reason":           "stop_loss",
+					"entry_price":      pos.EntryPrice,
+					"highest_price":    pos.HighestPrice,
+					"current_drawdown": currentDrawdown,
+				},
+			}
+
+			// Reset position tracking
+			delete(s.positions, data.Symbol)
+			return signal, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// Name implements strategy.Strategy
+func (s *StopLossStrategy) Name() string {
+	return s.name
+}
+
+// Parameters implements strategy.Strategy
+func (s *StopLossStrategy) Parameters() map[string]interface{} {
+	return map[string]interface{}{
+		"max_drawdown_percent": s.maxDrawdownPercent,
+	}
+}
+
+// UpdateParameters implements strategy.Strategy
+func (s *StopLossStrategy) UpdateParameters(params map[string]interface{}) error {
+	maxDrawdown, ok := params["max_drawdown_percent"].(float64)
+	if !ok {
+		return fmt.Errorf("max_drawdown_percent must be a float64")
+	}
+
+	if maxDrawdown <= 0 || maxDrawdown >= 100 {
+		return fmt.Errorf("max_drawdown_percent must be between 0 and 100")
+	}
+
+	s.mu.Lock()
+	s.maxDrawdownPercent = maxDrawdown
+	s.mu.Unlock()
+
+	return nil
+}
+
+// Cleanup implements strategy.Strategy
+func (s *StopLossStrategy) Cleanup(ctx context.Context) error {
+	return nil
+}

--- a/strategy-engine/internal/strategy/stoploss/strategy_test.go
+++ b/strategy-engine/internal/strategy/stoploss/strategy_test.go
@@ -1,0 +1,185 @@
+package stoploss
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewStopLossStrategy(t *testing.T) {
+	tests := []struct {
+		name          string
+		params        map[string]interface{}
+		expectedError bool
+	}{
+		{
+			name: "valid parameters",
+			params: map[string]interface{}{
+				"max_drawdown_percent": 5.0,
+			},
+			expectedError: false,
+		},
+		{
+			name: "invalid parameter type",
+			params: map[string]interface{}{
+				"max_drawdown_percent": "5.0", // string instead of float64
+			},
+			expectedError: true,
+		},
+		{
+			name: "invalid drawdown value - negative",
+			params: map[string]interface{}{
+				"max_drawdown_percent": -1.0,
+			},
+			expectedError: true,
+		},
+		{
+			name: "invalid drawdown value - too large",
+			params: map[string]interface{}{
+				"max_drawdown_percent": 100.1,
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			strategy, err := NewStopLossStrategy(tt.params)
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, strategy)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, strategy)
+			}
+		})
+	}
+}
+
+func TestStopLossStrategy_ProcessData(t *testing.T) {
+	// Create a strategy with 5% max drawdown
+	s, err := NewStopLossStrategy(map[string]interface{}{
+		"max_drawdown_percent": 5.0,
+	})
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+	now := time.Now()
+
+	// Helper function to create market data
+	createMarketData := func(price float64, timestamp time.Time) struct {
+		Symbol    string
+		Price     float64
+		Volume    float64
+		Timestamp time.Time
+	} {
+		return struct {
+			Symbol    string
+			Price     float64
+			Volume    float64
+			Timestamp time.Time
+		}{
+			Symbol:    "BTC-USD",
+			Price:     price,
+			Volume:    1.0,
+			Timestamp: timestamp,
+		}
+	}
+
+	// Test scenario 1: Initial position setup
+	data := createMarketData(50000.0, now)
+	s.positions[data.Symbol] = Position{
+		EntryPrice:     data.Price,
+		HighestPrice:   data.Price,
+		Quantity:       1.0,
+		LastUpdateTime: data.Timestamp,
+	}
+	signal, err := s.ProcessData(ctx, data)
+	assert.NoError(t, err)
+	assert.Nil(t, signal)
+	// Test scenario 2: Price increase (no signal)
+	data = createMarketData(51000.0, now.Add(time.Minute))
+	signal, err = s.ProcessData(ctx, data)
+	assert.NoError(t, err)
+	assert.Nil(t, signal)
+	assert.Equal(t, 51000.0, s.positions[data.Symbol].HighestPrice)
+
+	// Test scenario 3: Small drawdown (no signal)
+	data = createMarketData(48500.0, now.Add(2*time.Minute)) // 4.9% drawdown
+	signal, err = s.ProcessData(ctx, data)
+	assert.NoError(t, err)
+	assert.Nil(t, signal)
+
+	// Test scenario 4: Large drawdown (sell signal)
+	data = createMarketData(48000.0, now.Add(3*time.Minute)) // 5.88% drawdown
+	signal, err = s.ProcessData(ctx, data)
+	assert.NoError(t, err)
+	assert.NotNil(t, signal)
+	if signal != nil {
+		assert.Equal(t, "SELL", string(signal.Action))
+		assert.Equal(t, data.Price, signal.Price)
+		assert.Equal(t, 1.0, signal.Quantity)
+		assert.Equal(t, data.Symbol, signal.Symbol)
+		assert.Equal(t, "stop_loss", signal.Metadata["reason"])
+		assert.Equal(t, 50000.0, signal.Metadata["entry_price"])
+		assert.Equal(t, 51000.0, signal.Metadata["highest_price"])
+		drawdown, ok := signal.Metadata["current_drawdown"].(float64)
+		assert.True(t, ok)
+		assert.InDelta(t, 5.88, drawdown, 0.01)
+	}
+	// Test scenario 5: After stop loss (no position, no signal)
+	data = createMarketData(47000.0, now.Add(4*time.Minute))
+	signal, err = s.ProcessData(ctx, data)
+	assert.NoError(t, err)
+	assert.Nil(t, signal)
+}
+
+func TestStopLossStrategy_UpdateParameters(t *testing.T) {
+	strategy, err := NewStopLossStrategy(map[string]interface{}{
+		"max_drawdown_percent": 5.0,
+	})
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		params        map[string]interface{}
+		expectedError bool
+	}{
+		{
+			name: "valid update",
+			params: map[string]interface{}{
+				"max_drawdown_percent": 10.0,
+			},
+			expectedError: false,
+		},
+		{
+			name: "invalid type",
+			params: map[string]interface{}{
+				"max_drawdown_percent": "10.0",
+			},
+			expectedError: true,
+		},
+		{
+			name: "invalid value",
+			params: map[string]interface{}{
+				"max_drawdown_percent": -1.0,
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := strategy.UpdateParameters(tt.params)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				params := strategy.Parameters()
+				assert.Equal(t, tt.params["max_drawdown_percent"], params["max_drawdown_percent"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
A single stop-loss strategy without reading the actual initial position. 
Currently, it only records the price it sees since the strategy-engine service starts and calculates the max drawdown, if it exceeds then it generates a sell signal.